### PR TITLE
chore: Add a simple README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Homebrew Formula for Syft
+
+This repo contains the [Homebrew](https://brew.sh/) formula for
+[Syft](https://github.com/anchore/syft)
+
+## Installation
+
+```sh
+brew tap anchore/syft
+brew install syft
+```
+
+## Issues, Feature Requests, etc...
+
+If you have any problems related to the installation of Syft via Homebrew,
+please [open an issue](https://github.com/anchore/homebrew-syft/issues/new)
+
+Any issues or feature requests related to Syft itself should be filed in the
+[Syft repo](https://github.com/anchore/syft)


### PR DESCRIPTION
If you search with intent (i.e. google "homebrew syft") then this repo shows up above Syft itself. This readme adds a little clarity and basic usage instructions